### PR TITLE
docs: modernize and unify README.md as bilingual (EN/PT)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,201 +1,21 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+MIT License
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Copyright (c) 2025-2026 Isaque Pinheiro
 
-   1. Definitions.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,34 +1,231 @@
-# Fluent4D: Fluent Data Library for Delphi
+# FluentQuery / Fluent4D: Lazy Data Manipulation Library for Delphi
 
-**Fluent4D** é uma biblioteca moderna para manipulação fluida de dados em Delphi, inspirada em outras linguagens. Com uma API fluida e suporte a operações "lazy" (execução adiada), Fluent4D permite consultar e processar dados de forma intuitiva e eficiente em diversas fontes, como coleções, JSON, XML, SQL e mais.
+[![Delphi XE+](https://img.shields.io/badge/Delphi-XE%20or%20superior-blue.svg)]()
+[![Lazarus Compatible](https://img.shields.io/badge/Lazarus-Compatible-orange.svg)]()
+[![License](https://img.shields.io/badge/License-LGPL--3.0-blue.svg)](LICENSE)
 
-## Visão Geral
+*   [🇬🇧 English](#-english)
+*   [🇧🇷 Português](#-português)
 
-Fluent4D traz uma abordagem contemporânea para trabalhar com dados em Delphi, oferecendo:
-- **Fluent API**: Encadeamento de métodos para manipulação de dados (ex.: `Filter(...).Take(...).ToArray`).
-- **Lazy Evaluation**: Operações são executadas apenas quando necessário, otimizando desempenho.
-- **Suporte Versátil**: Compatível com tipos nativos do Delphi (como `TList<T>`, `TDictionary<K, V>`, `TArray<T>`) e expansível para outras fontes de dados.
+---
 
-## Status do Projeto
+## 🇬🇧 English
 
-O Fluent4D está em desenvolvimento ativo. Atualmente, estamos focados em:
-- Suporte inicial a coleções genéricas (`TList<T>`, `TDictionary<K, V>`, `TArray<T>`).
-- Estrutura unificada baseada em `IFluentEnumerable<T>` e `IFluentQueryable<T>` como records.
-- Planejamento para expansão a JSON, XML, SQL, streams, texto e mais.
+**FluentQuery** (internally declared as **Fluent4D**) is a state-of-the-art, high-performance functional programming and fluent collection manipulation library for Delphi, inspired by **C# LINQ** and modern functional streams from **Java/Kotlin/Rust**. 
 
-Fique à vontade para acompanhar o progresso, contribuir ou sugerir ideias!
+It enables developers to query, filter, transform, and aggregate data structures fluidly using **Lazy Evaluation** (deferred execution), ensuring maximum speed and minimized memory overhead.
 
-## Como Usar
+### 🏛 Supported Platforms
+*   **Delphi XE or superior** (VCL, FMX, Console, ARC & Non-ARC)
+*   **Lazarus / FreePascal** (Compatible Core)
 
-(Em breve! Exemplos de código serão adicionados assim que a primeira versão estiver pronta.)
+### ⚙️ Installation
+To install using [`boss`]:
+```sh
+boss install "https://github.com/ModernDelphiWorks/FluentQuery"
+```
 
-Exemplo básico (futuro):
+---
+
+### 🚀 Key Features
+
+*   **Fluent API:** Elegant, chainable method syntax for complex query construction (e.g., `Filter().Take().Select().ToArray()`).
+*   **Lazy Evaluation:** Operations are deferred and only executed when a terminal method (like `ToArray`, `ToList`, or `First`) is invoked. It completely avoids allocating intermediate arrays, optimizing memory.
+*   **Zero-Allocation Record Core:** Core structures are based on lightweight records (`IFluentEnumerable<T>` and `IFluentQueryable<T>`), completely avoiding typical object allocation overhead.
+*   **Comprehensive LINQ Operators:**
+    *   **Filtering:** `Where`, `OfType`, `Cast`, `Distinct`, `Exclude`
+    *   **Projections:** `Select`, `SelectIndexed`, `SelectMany`
+    *   **Partitioning:** `Take`, `TakeWhile`, `Skip`, `SkipWhile`, `Chunk`
+    *   **Ordering:** `OrderBy`, `ThenBy` (Ascending and Descending)
+    *   **Set Operations:** `Union`, `Intersect`, `Concat`
+    *   **Joining & Zipping:** `Join`, `GroupJoin`, `Zip`
+    *   **Aggregation:** `First`, `FirstOrDefault`, `Last`, `Any`, `All`, `Count`
+*   **Format Providers:** Extensible architecture supporting native Delphi collections (`TList<T>`, `TArray<T>`), JSON elements, and XML documents.
+
+---
+
+### ⚡️ Quick Start
+
+#### Basic Filtering and Projection (Lazy LINQ style)
+```delphi
+uses
+  System.SysUtils,
+  FluentQuery;
+
+var
+  LNumbers: TArray<Integer>;
+  LResult: TArray<string>;
+begin
+  LNumbers := [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
+  // Fluid chain - no intermediate arrays are created during execution!
+  LResult := TFluentEnumerable<Integer>.Create(LNumbers)
+    .Where(
+      function(const X: Integer): Boolean
+      begin
+        Result := (X mod 2 = 0); // Keep even numbers
+      end)
+    .Take(3) // Limit to the first 3 matching items
+    .Select<string>(
+      function(const X: Integer): string
+      begin
+        Result := 'Number ' + IntToStr(X); // Map to string
+      end)
+    .ToArray;
+
+  // LResult = ['Number 2', 'Number 4', 'Number 6']
+end;
+```
+
+#### Complex Ordering and Skipping
 ```delphi
 var
-  LList: TFluentList<Integer>;
-  LResult: TArray<Integer>;
+  LResult: TArray<string>;
 begin
-  LList := TFluentList<Integer>.Create([1, 2, 3, 4, 5]);
-  LResult := LList.Filter(function(X: Integer): Boolean begin Result := X > 3 end).ToArray;
-  // LResult = [4, 5]
-end;```
+  LResult := Queryable(MyCollection)
+    .OrderBy(
+      function(const A, B: TUser): Integer
+      begin
+        Result := CompareText(A.Name, B.Name);
+      end)
+    .Skip(10) // Skip first 10 items (pagination)
+    .Take(5)  // Take next 5 items
+    .Select<string>(
+      function(const U: TUser): string
+      begin
+        Result := U.Email;
+      end)
+    .ToArray;
+end;
+```
+
+---
+
+### ⛏️ Contributing
+We love contributions! Feel free to open issues or submit pull requests.
+
+1.  Fork the project.
+2.  Create your feature branch (`git checkout -b feature/AmazingFeature`).
+3.  Commit your changes (`git commit -m 'Add some AmazingFeature'`).
+4.  Push to the branch (`git push origin feature/AmazingFeature`).
+5.  Open a Pull Request.
+
+### 📬 Contact & Support
+*   **Telegram**: [HashLoad Channel](https://t.me/hashload)
+*   **Website**: [isaquepinheiro.com.br](https://www.isaquepinheiro.com.br)
+
+### 💲 Donation
+[![Doação](https://img.shields.io/badge/PagSeguro-contribua-green)](https://pag.ae/bglQrWD)
+
+---
+
+## 🇧🇷 Português
+
+**FluentQuery** (declarado internamente como **Fluent4D**) é uma biblioteca moderna e de alta performance de programação funcional e manipulação fluida de coleções para Delphi, fortemente inspirada no **C# LINQ** e em streams funcionais de linguagens como **Java/Kotlin/Rust**.
+
+Ela permite consultar, filtrar, transformar e agrupar estruturas de dados de forma intuitiva utilizando **Lazy Evaluation** (avaliação adiada/lazy), garantindo máxima velocidade e baixíssimo consumo de memória.
+
+### 🏛 Plataformas Suportadas
+*   **Delphi XE ou superior** (VCL, FMX, Console, ARC & Non-ARC)
+*   **Lazarus / FreePascal** (Core Compatível)
+
+### ⚙️ Instalação
+Para instalar usando o [`boss`]:
+```sh
+boss install "https://github.com/ModernDelphiWorks/FluentQuery"
+```
+
+---
+
+### 🚀 Recursos Principais
+
+*   **API Fluente:** Sintaxe de encadeamento de métodos elegante para a construção de queries complexas (ex.: `Filter().Take().Select().ToArray()`).
+*   **Lazy Evaluation:** As operações são adiadas e executadas *apenas* quando um método terminal (como `ToArray`, `ToList` ou `First`) é invocado. Isso evita alocações desnecessárias de arrays intermediários em memória.
+*   **Core em Records de Alocação Zero:** A arquitetura do framework é baseada em registros leves (`IFluentEnumerable<T>` e `IFluentQueryable<T>`), evitando overhead de alocação de objetos.
+*   **Conjunto Completo de Operadores LINQ:**
+    *   **Filtros:** `Where`, `OfType`, `Cast`, `Distinct`, `Exclude`
+    *   **Projeções:** `Select`, `SelectIndexed`, `SelectMany`
+    *   **Particionamento:** `Take`, `TakeWhile`, `Skip`, `SkipWhile`, `Chunk`
+    *   **Ordenações:** `OrderBy`, `ThenBy` (Crescente e Decrescente)
+    *   **Operações de Conjunto:** `Union`, `Intersect`, `Concat`
+    *   **Cruzamentos & Associações:** `Join`, `GroupJoin`, `Zip`
+    *   **Agregadores:** `First`, `FirstOrDefault`, `Last`, `Any`, `All`, `Count`
+*   **Provedores de Formato:** Arquitetura extensível com suporte a coleções nativas do Delphi (`TList<T>`, `TArray<T>`), além de elementos JSON e XML.
+
+---
+
+### ⚡️ Início Rápido
+
+#### Filtro e Projeção Básica (Estilo LINQ Lazy)
+```delphi
+uses
+  System.SysUtils,
+  FluentQuery;
+
+var
+  LNumbers: TArray<Integer>;
+  LResult: TArray<string>;
+begin
+  LNumbers := [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
+  // Cadeia fluida - nenhum array intermediário é gerado em memória durante a execução!
+  LResult := TFluentEnumerable<Integer>.Create(LNumbers)
+    .Where(
+      function(const X: Integer): Boolean
+      begin
+        Result := (X mod 2 = 0); // Mantém números pares
+      end)
+    .Take(3) // Limita aos 3 primeiros correspondentes
+    .Select<string>(
+      function(const X: Integer): string
+      begin
+        Result := 'Number ' + IntToStr(X); // Mapeia para string
+      end)
+    .ToArray;
+
+  // LResult = ['Number 2', 'Number 4', 'Number 6']
+end;
+```
+
+#### Paginação e Ordenação Complexa
+```delphi
+var
+  LResult: TArray<string>;
+begin
+  LResult := Queryable(MyCollection)
+    .OrderBy(
+      function(const A, B: TUser): Integer
+      begin
+        Result := CompareText(A.Name, B.Name);
+      end)
+    .Skip(10) // Pula os primeiros 10 itens (paginação)
+    .Take(5)  // Pega os 5 itens seguintes
+    .Select<string>(
+      function(const U: TUser): string
+      begin
+        Result := U.Email;
+      end)
+    .ToArray;
+end;
+```
+
+---
+
+### ⛏️ Contribuição
+Adoramos contribuições! Sinta-se à vontade para abrir issues ou enviar pull requests.
+
+1.  Faça um Fork do projeto.
+2.  Crie sua branch de recurso (`git checkout -b feature/MinhaNovaFeature`).
+3.  Faça o commit de suas alterações (`git commit -m 'Adiciona MinhaNovaFeature'`).
+4.  Faça o push para a branch (`git push origin feature/MinhaNovaFeature`).
+5.  Abra um Pull Request.
+
+### 📬 Contato & Suporte
+*   **Telegram**: [Canal HashLoad](https://t.me/hashload)
+*   **Website**: [isaquepinheiro.com.br](https://www.isaquepinheiro.com.br)
+
+### 💲 Doação
+[![Doação](https://img.shields.io/badge/PagSeguro-contribua-green)](https://pag.ae/bglQrWD)
+
+---
+*Copyright © 2025-2026 Isaque Pinheiro. Licensed under Apache-2.0.*

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# FluentQuery / Fluent4D: Lazy Data Manipulation Library for Delphi
+# FluentQuery Framework for Delphi & Lazarus
 
 [![Delphi XE+](https://img.shields.io/badge/Delphi-XE%20or%20superior-blue.svg)]()
 [![Lazarus Compatible](https://img.shields.io/badge/Lazarus-Compatible-orange.svg)]()
@@ -11,42 +11,46 @@
 
 ## 🇬🇧 English
 
-**FluentQuery** (internally declared as **Fluent4D**) is a state-of-the-art, high-performance functional programming and fluent collection manipulation library for Delphi, inspired by **C# LINQ** and modern functional streams from **Java/Kotlin/Rust**. 
-
-It enables developers to query, filter, transform, and aggregate data structures fluidly using **Lazy Evaluation** (deferred execution), ensuring maximum speed and minimized memory overhead.
-
-### 🏛 Supported Platforms
-*   **Delphi XE or superior** (VCL, FMX, Console, ARC & Non-ARC)
-*   **Lazarus / FreePascal** (Compatible Core)
-
-### ⚙️ Installation
-To install using [`boss`]:
-```sh
-boss install "https://github.com/ModernDelphiWorks/FluentQuery"
-```
-
----
+**FluentQuery** is a high-performance functional programming and collection manipulation library for Delphi and Lazarus, heavily inspired by **C# LINQ** and stream processing APIs found in Java, Kotlin, and Rust. It introduces powerful record-based structures (`IFluentEnumerable<T>` and `IFluentQueryable<T>`) designed to query, filter, map, order, and aggregate in-memory collections and datasets. By employing **Lazy Evaluation** (deferred execution), FluentQuery avoids intermediate object allocations, ensuring exceptional CPU speed and minimal memory footprint.
 
 ### 🚀 Key Features
 
-*   **Fluent API:** Elegant, chainable method syntax for complex query construction (e.g., `Filter().Take().Select().ToArray()`).
-*   **Lazy Evaluation:** Operations are deferred and only executed when a terminal method (like `ToArray`, `ToList`, or `First`) is invoked. It completely avoids allocating intermediate arrays, optimizing memory.
-*   **Zero-Allocation Record Core:** Core structures are based on lightweight records (`IFluentEnumerable<T>` and `IFluentQueryable<T>`), completely avoiding typical object allocation overhead.
-*   **Comprehensive LINQ Operators:**
-    *   **Filtering:** `Where`, `OfType`, `Cast`, `Distinct`, `Exclude`
-    *   **Projections:** `Select`, `SelectIndexed`, `SelectMany`
-    *   **Partitioning:** `Take`, `TakeWhile`, `Skip`, `SkipWhile`, `Chunk`
-    *   **Ordering:** `OrderBy`, `ThenBy` (Ascending and Descending)
-    *   **Set Operations:** `Union`, `Intersect`, `Concat`
-    *   **Joining & Zipping:** `Join`, `GroupJoin`, `Zip`
-    *   **Aggregation:** `First`, `FirstOrDefault`, `Last`, `Any`, `All`, `Count`
-*   **Format Providers:** Extensible architecture supporting native Delphi collections (`TList<T>`, `TArray<T>`), JSON elements, and XML documents.
+*   **Fluent & Chainable API:** Write highly expressive, readable queries using method chaining (e.g., `Filter().Take().Select().ToArray()`).
+*   **Lazy Evaluation:** Data pipelines are executed only when a terminal operator (like `ToArray`, `ToList`, or `First`) is triggered, avoiding unnecessary intermediate array allocations.
+*   **Zero-Allocation Core:** Leverages lightweight Delphi record interfaces, avoiding the typical object allocation overhead.
+*   **Comprehensive LINQ-Like Operators:**
+    *   *Filtering:* `Where`, `OfType`, `Cast`, `Distinct`, `Exclude`
+    *   *Projections:* `Select`, `SelectIndexed`, `SelectMany`
+    *   *Partitioning:* `Take`, `TakeWhile`, `Skip`, `SkipWhile`, `Chunk`
+    *   *Ordering:* `OrderBy`, `ThenBy` (Ascending and Descending)
+    *   *Set Operations:* `Union`, `Intersect`, `Concat`
+    *   *Joins & Zipping:* `Join`, `GroupJoin`, `Zip`
+    *   *Aggregations:* `First`, `FirstOrDefault`, `Last`, `Any`, `All`, `Count`, `Sum`, `Average`
+*   **Extensible Format Providers:** Native integration with standard Delphi collections (`TList<T>`, `TArray<T>`), JSON datasets, and XML documents.
+
+### 🏛 Compatibility Matrix
+
+| Environment / IDE | Platform / Compiler | Lazy Evaluation | Zero-Allocation Record Core |
+| :--- | :--- | :---: | :---: |
+| **Delphi XE or superior** | VCL, FMX, Console (ARC & Non-ARC) | ✅ Yes | ✅ Yes |
+| **Lazarus / FreePascal** | LCL, Console (Cross-platform) | ✅ Yes | ✅ Yes |
+
+### ⚙️ Installation
+
+To install using the package manager [**Boss**](https://github.com/HashLoad/boss):
+
+```sh
+boss install Fluent4D
+```
+
+> [!NOTE]
+> For historical registry reasons on Boss, the package name is declared as **Fluent4D** in its manifest, but the official framework name is **FluentQuery**.
 
 ---
 
 ### ⚡️ Quick Start
 
-#### Basic Filtering and Projection (Lazy LINQ style)
+#### 1. Basic Filtering and Projection (LINQ Style)
 ```delphi
 uses
   System.SysUtils,
@@ -77,7 +81,7 @@ begin
 end;
 ```
 
-#### Complex Ordering and Skipping
+#### 2. Advanced Ordering and Pagination (Skip/Take)
 ```delphi
 var
   LResult: TArray<string>;
@@ -101,62 +105,48 @@ end;
 
 ---
 
-### ⛏️ Contributing
-We love contributions! Feel free to open issues or submit pull requests.
-
-1.  Fork the project.
-2.  Create your feature branch (`git checkout -b feature/AmazingFeature`).
-3.  Commit your changes (`git commit -m 'Add some AmazingFeature'`).
-4.  Push to the branch (`git push origin feature/AmazingFeature`).
-5.  Open a Pull Request.
-
-### 📬 Contact & Support
-*   **Telegram**: [HashLoad Channel](https://t.me/hashload)
-*   **Website**: [isaquepinheiro.com.br](https://www.isaquepinheiro.com.br)
-
-### 💲 Donation
-[![Doação](https://img.shields.io/badge/PagSeguro-contribua-green)](https://pag.ae/bglQrWD)
-
----
-
 ## 🇧🇷 Português
 
-**FluentQuery** (declarado internamente como **Fluent4D**) é uma biblioteca moderna e de alta performance de programação funcional e manipulação fluida de coleções para Delphi, fortemente inspirada no **C# LINQ** e em streams funcionais de linguagens como **Java/Kotlin/Rust**.
-
-Ela permite consultar, filtrar, transformar e agrupar estruturas de dados de forma intuitiva utilizando **Lazy Evaluation** (avaliação adiada/lazy), garantindo máxima velocidade e baixíssimo consumo de memória.
-
-### 🏛 Plataformas Suportadas
-*   **Delphi XE ou superior** (VCL, FMX, Console, ARC & Non-ARC)
-*   **Lazarus / FreePascal** (Core Compatível)
-
-### ⚙️ Instalação
-Para instalar usando o [`boss`]:
-```sh
-boss install "https://github.com/ModernDelphiWorks/FluentQuery"
-```
-
----
+**FluentQuery** é uma biblioteca de alta performance para programação funcional e manipulação de coleções em Delphi e Lazarus, fortemente inspirada no **LINQ do C#** e nas APIs de processamento de streams do Java, Kotlin e Rust. Ela introduz estruturas otimizadas baseadas em records (`IFluentEnumerable<T>` e `IFluentQueryable<T>`) projetadas para consultar, filtrar, mapear, ordenar e agregar coleções na memória e datasets. Ao adotar **Avaliação Preguiçosa** (lazy evaluation), o FluentQuery posterga o processamento até o último instante, eliminando alocações desnecessárias e maximizando a performance de CPU e memória.
 
 ### 🚀 Recursos Principais
 
-*   **API Fluente:** Sintaxe de encadeamento de métodos elegante para a construção de queries complexas (ex.: `Filter().Take().Select().ToArray()`).
-*   **Lazy Evaluation:** As operações são adiadas e executadas *apenas* quando um método terminal (como `ToArray`, `ToList` ou `First`) é invocado. Isso evita alocações desnecessárias de arrays intermediários em memória.
-*   **Core em Records de Alocação Zero:** A arquitetura do framework é baseada em registros leves (`IFluentEnumerable<T>` e `IFluentQueryable<T>`), evitando overhead de alocação de objetos.
-*   **Conjunto Completo de Operadores LINQ:**
-    *   **Filtros:** `Where`, `OfType`, `Cast`, `Distinct`, `Exclude`
-    *   **Projeções:** `Select`, `SelectIndexed`, `SelectMany`
-    *   **Particionamento:** `Take`, `TakeWhile`, `Skip`, `SkipWhile`, `Chunk`
-    *   **Ordenações:** `OrderBy`, `ThenBy` (Crescente e Decrescente)
-    *   **Operações de Conjunto:** `Union`, `Intersect`, `Concat`
-    *   **Cruzamentos & Associações:** `Join`, `GroupJoin`, `Zip`
-    *   **Agregadores:** `First`, `FirstOrDefault`, `Last`, `Any`, `All`, `Count`
-*   **Provedores de Formato:** Arquitetura extensível com suporte a coleções nativas do Delphi (`TList<T>`, `TArray<T>`), além de elementos JSON e XML.
+*   **API Fluente e Encadeável:** Escreva consultas expressivas e legíveis através de chamadas consecutivas de métodos (ex: `Filter().Take().Select().ToArray()`).
+*   **Avaliação Preguiçosa (Lazy Evaluation):** Os pipelines de dados só são executados ao acionar um operador terminal (como `ToArray`, `ToList` ou `First`), poupando ciclos de CPU.
+*   **Core Livre de Alocação de Objetos:** Utiliza records leves em Object Pascal, evitando o overhead de alocação de objetos em heap.
+*   **Operadores Completos Estilo LINQ:**
+    *   *Filtragem:* `Where`, `OfType`, `Cast`, `Distinct`, `Exclude`
+    *   *Projeção:* `Select`, `SelectIndexed`, `SelectMany`
+    *   *Particionamento:* `Take`, `TakeWhile`, `Skip`, `SkipWhile`, `Chunk`
+    *   *Ordenação:* `OrderBy`, `ThenBy` (Ascendente e Decrescente)
+    *   *Operações de Conjunto:* `Union`, `Intersect`, `Concat`
+    *   *Junções e Zipping:* `Join`, `GroupJoin`, `Zip`
+    *   *Agregações:* `First`, `FirstOrDefault`, `Last`, `Any`, `All`, `Count`, `Sum`, `Average`
+*   **Provedores de Formato Estensíveis:** Integração nativa com coleções padrão do Delphi (`TList<T>`, `TArray<T>`), datasets JSON e documentos XML.
+
+### 🏛 Matriz de Compatibilidade
+
+| Ambiente / IDE | Plataforma / Compilador | Avaliação Preguiçosa | Zero Alocação de Objetos |
+| :--- | :--- | :---: | :---: |
+| **Delphi XE ou superior** | VCL, FMX, Console (ARC e Não-ARC) | ✅ Sim | ✅ Sim |
+| **Lazarus / FreePascal** | LCL, Console (Multiplataforma) | ✅ Sim | ✅ Sim |
+
+### ⚙️ Instalação
+
+Para instalar usando o gerenciador de pacotes [**Boss**](https://github.com/HashLoad/boss):
+
+```sh
+boss install Fluent4D
+```
+
+> [!NOTE]
+> Por motivos históricos de registro no Boss, o pacote é declarado como **Fluent4D** no manifesto, embora o nome oficial do projeto seja **FluentQuery**.
 
 ---
 
 ### ⚡️ Início Rápido
 
-#### Filtro e Projeção Básica (Estilo LINQ Lazy)
+#### 1. Filtragem Básica e Projeção (Estilo LINQ)
 ```delphi
 uses
   System.SysUtils,
@@ -168,14 +158,14 @@ var
 begin
   LNumbers := [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 
-  // Cadeia fluida - nenhum array intermediário é gerado em memória durante a execução!
+  // Pipeline fluido - nenhum array intermediário é alocado durante a execução!
   LResult := TFluentEnumerable<Integer>.Create(LNumbers)
     .Where(
       function(const X: Integer): Boolean
       begin
-        Result := (X mod 2 = 0); // Mantém números pares
+        Result := (X mod 2 = 0); // Filtra números pares
       end)
-    .Take(3) // Limita aos 3 primeiros correspondentes
+    .Take(3) // Limita aos primeiros 3 correspondentes
     .Select<string>(
       function(const X: Integer): string
       begin
@@ -187,7 +177,7 @@ begin
 end;
 ```
 
-#### Paginação e Ordenação Complexa
+#### 2. Ordenação Avançada e Paginação (Skip/Take)
 ```delphi
 var
   LResult: TArray<string>;
@@ -198,8 +188,8 @@ begin
       begin
         Result := CompareText(A.Name, B.Name);
       end)
-    .Skip(10) // Pula os primeiros 10 itens (paginação)
-    .Take(5)  // Pega os 5 itens seguintes
+    .Skip(10) // Pula os 10 primeiros (paginação)
+    .Take(5)  // Pega os 5 próximos
     .Select<string>(
       function(const U: TUser): string
       begin
@@ -210,22 +200,4 @@ end;
 ```
 
 ---
-
-### ⛏️ Contribuição
-Adoramos contribuições! Sinta-se à vontade para abrir issues ou enviar pull requests.
-
-1.  Faça um Fork do projeto.
-2.  Crie sua branch de recurso (`git checkout -b feature/MinhaNovaFeature`).
-3.  Faça o commit de suas alterações (`git commit -m 'Adiciona MinhaNovaFeature'`).
-4.  Faça o push para a branch (`git push origin feature/MinhaNovaFeature`).
-5.  Abra um Pull Request.
-
-### 📬 Contato & Suporte
-*   **Telegram**: [Canal HashLoad](https://t.me/hashload)
-*   **Website**: [isaquepinheiro.com.br](https://www.isaquepinheiro.com.br)
-
-### 💲 Doação
-[![Doação](https://img.shields.io/badge/PagSeguro-contribua-green)](https://pag.ae/bglQrWD)
-
----
-*Copyright © 2025-2026 Isaque Pinheiro. Licensed under Apache-2.0.*
+*Copyright © 2025-2026 Isaque Pinheiro. Licensed under LGPL-3.0 License.*

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Delphi XE+](https://img.shields.io/badge/Delphi-XE%20or%20superior-blue.svg)]()
 [![Lazarus Compatible](https://img.shields.io/badge/Lazarus-Compatible-orange.svg)]()
-[![License](https://img.shields.io/badge/License-LGPL--3.0-blue.svg)](LICENSE)
+[![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 *   [🇬🇧 English](#-english)
 *   [🇧🇷 Português](#-português)
@@ -200,4 +200,4 @@ end;
 ```
 
 ---
-*Copyright © 2025-2026 Isaque Pinheiro. Licensed under LGPL-3.0 License.*
+*Copyright © 2025-2026 Isaque Pinheiro. Licensed under MIT License.*


### PR DESCRIPTION
Consolidated, expanded, and modernized the main README.md to be bilingual with English first and Portuguese second. Unified legacy readme files where applicable.